### PR TITLE
Add user registration page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,7 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import Register from './Register'
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  return <Register />
 }
 
 export default App

--- a/src/Register.css
+++ b/src/Register.css
@@ -1,0 +1,30 @@
+.register-container {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: left;
+}
+
+.register-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.register-form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+}
+
+.register-form input {
+  padding: 0.5rem;
+  font-size: 1rem;
+  margin-top: 0.25rem;
+}
+
+.register-form button {
+  padding: 0.75rem;
+  font-size: 1rem;
+  cursor: pointer;
+}

--- a/src/Register.tsx
+++ b/src/Register.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react'
+import './Register.css'
+
+function Register() {
+  const [formData, setFormData] = useState({
+    username: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  })
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    // For now just log the data.
+    console.log('Registering user', formData)
+  }
+
+  return (
+    <div className="register-container">
+      <h2>新規登録</h2>
+      <form className="register-form" onSubmit={handleSubmit}>
+        <label>
+          ユーザー名
+          <input
+            type="text"
+            name="username"
+            value={formData.username}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label>
+          メールアドレス
+          <input
+            type="email"
+            name="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label>
+          パスワード
+          <input
+            type="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label>
+          パスワード（確認）
+          <input
+            type="password"
+            name="confirmPassword"
+            value={formData.confirmPassword}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <button type="submit">登録</button>
+      </form>
+    </div>
+  )
+}
+
+export default Register


### PR DESCRIPTION
## Summary
- Replace default content with a simple user registration screen
- Style registration form and wire state handling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b95b3548c4833392912b3198d5dffc